### PR TITLE
Update super_i2c.tbs

### DIFF
--- a/Project/super_i2c.tbs
+++ b/Project/super_i2c.tbs
@@ -235,14 +235,13 @@ function si2c_read(acknak_request as boolean) as byte
 		next bitCnt
 
 		io.num = si2c_sda(si2c_num)				'Select SSI_SDA line
+		io.enabled=YES						'Enable SSI_DO as output
 
 		if acknak_request=TRUE then				'Does user want to send an ack or not
 			io.state = LOW						'Bring Low for ACK
 		else
 			io.state = HIGH						'Bring high for NACK
 		end if	
-
-		io.enabled=YES							'Enable SSI_DO as output
 
 		io.num=si2c_scl(si2c_num)				'Select SSI_CLK line
 		io.state=HIGH							'Set SSI_CLK line


### PR DESCRIPTION
misordered operation: need to set SDA to OUT before setting SDA line to 0 or 1